### PR TITLE
Refactor to use fix_times everywhere

### DIFF
--- a/src/pytroll_watchers/local_watcher.py
+++ b/src/pytroll_watchers/local_watcher.py
@@ -9,7 +9,7 @@ from urllib.parse import urlunparse
 from upath import UPath
 
 from pytroll_watchers.backends.local import listen_to_local_events
-from pytroll_watchers.publisher import file_publisher_from_generator, fix_times, parse_metadata
+from pytroll_watchers.publisher import file_publisher_from_generator, parse_metadata
 
 
 def file_publisher(fs_config, publisher_config, message_config):

--- a/src/pytroll_watchers/minio_notification_watcher.py
+++ b/src/pytroll_watchers/minio_notification_watcher.py
@@ -1,11 +1,8 @@
 """Publish messages based on Minio bucket notifications."""
 
-import datetime
-
-from trollsift import parse
 from upath import UPath
 
-from pytroll_watchers.publisher import file_publisher_from_generator
+from pytroll_watchers.publisher import file_publisher_from_generator, fix_times, parse_metadata
 
 
 def file_publisher(fs_config, publisher_config, message_config):
@@ -51,12 +48,10 @@ def file_generator(endpoint_url, bucket_name, file_pattern=None, storage_options
         for item in record["Records"]:
             new_bucket_name = item["s3"]["bucket"]["name"]
             new_file_name = item["s3"]["object"]["key"]
-            if file_pattern is not None:
-                try:
-                    file_metadata = parse(file_pattern, new_file_name)
-                    fix_times(file_metadata)
-                except ValueError:
-                    continue
+            try:
+                file_metadata = parse_metadata(file_pattern, new_file_name)
+            except ValueError:
+                continue
 
             path = UPath(f"s3://{new_bucket_name}/{new_file_name}", **storage_options)
             yield path, file_metadata
@@ -81,20 +76,3 @@ def _record_generator(endpoint_url, bucket_name, profile=None):
     ) as events:
         for event in events:
             yield event
-
-
-def fix_times(info):
-    """Fix times so that date and time components are combined."""
-    if "start_date" in info:
-        info["start_time"] = datetime.datetime.combine(info["start_date"].date(),
-                                                       info["start_time"].time())
-        if "end_date" not in info:
-            info["end_date"] = info["start_date"]
-        del info["start_date"]
-    if "end_date" in info:
-        info["end_time"] = datetime.datetime.combine(info["end_date"].date(),
-                                                     info["end_time"].time())
-        del info["end_date"]
-    if "end_time" in info:
-        while info["start_time"] > info["end_time"]:
-            info["end_time"] += datetime.timedelta(days=1)

--- a/src/pytroll_watchers/minio_notification_watcher.py
+++ b/src/pytroll_watchers/minio_notification_watcher.py
@@ -2,7 +2,7 @@
 
 from upath import UPath
 
-from pytroll_watchers.publisher import file_publisher_from_generator, fix_times, parse_metadata
+from pytroll_watchers.publisher import file_publisher_from_generator, parse_metadata
 
 
 def file_publisher(fs_config, publisher_config, message_config):

--- a/src/pytroll_watchers/publisher.py
+++ b/src/pytroll_watchers/publisher.py
@@ -2,9 +2,11 @@
 
 from contextlib import closing, suppress
 from copy import deepcopy
+import datetime
 
 from posttroll.message import Message
 from posttroll.publisher import create_publisher_from_dict_config
+from trollsift import parse
 
 
 def file_publisher_from_generator(generator, publisher_config, message_config):
@@ -29,3 +31,29 @@ def file_publisher_from_generator(generator, publisher_config, message_config):
             amended_message_config["data"].update(file_metadata)
             msg = Message(**amended_message_config)
             publisher.send(str(msg))
+
+
+def fix_times(info):
+    """Fix times so that date and time components are combined, and start time is before end time."""
+    if "start_date" in info:
+        info["start_time"] = datetime.datetime.combine(info["start_date"].date(),
+                                                       info["start_time"].time())
+        if "end_date" not in info:
+            info["end_date"] = info["start_date"]
+        del info["start_date"]
+    if "end_date" in info:
+        info["end_time"] = datetime.datetime.combine(info["end_date"].date(),
+                                                     info["end_time"].time())
+        del info["end_date"]
+    if "end_time" in info:
+        while info["start_time"] > info["end_time"]:
+            info["end_time"] += datetime.timedelta(days=1)
+
+def parse_metadata(file_pattern, path):
+    """Parse metadata from the filename."""
+    if file_pattern is not None:
+        file_metadata = parse(file_pattern, path)
+        fix_times(file_metadata)
+    else:
+        file_metadata = {}
+    return file_metadata

--- a/src/pytroll_watchers/publisher.py
+++ b/src/pytroll_watchers/publisher.py
@@ -1,8 +1,8 @@
 """Common functions for publishing messages."""
 
+import datetime
 from contextlib import closing, suppress
 from copy import deepcopy
-import datetime
 
 from posttroll.message import Message
 from posttroll.publisher import create_publisher_from_dict_config

--- a/tests/test_bucket_notification_watcher.py
+++ b/tests/test_bucket_notification_watcher.py
@@ -5,6 +5,7 @@ import datetime
 from posttroll.message import Message
 from posttroll.testing import patched_publisher
 from pytroll_watchers import minio_notification_watcher
+from pytroll_watchers.publisher import fix_times
 from pytroll_watchers.testing import patched_bucket_listener  # noqa
 from upath import UPath
 
@@ -65,7 +66,7 @@ def test_fix_times():
                 "orbit_number": 64498,
                 "processing_datetime": datetime.datetime(2024, 4, 8, 10, 23, 34, 392250)}
 
-    minio_notification_watcher.fix_times(metadata)
+    fix_times(metadata)
 
     assert metadata["start_time"] < metadata["end_time"]
 


### PR DESCRIPTION
This PR refactors the file parsing, so that the same actions can be used independently of the backend, eg fix_times