### PR TITLE
Add unpacking possibilities to the watcher

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -19,3 +19,16 @@ The command-line tool can be used by invoking `pytroll-watcher <config-file>`. A
      aliases:
        platform_name:
          npp: Suomi-NPP
+
+Unpacking of the file into it's component and subsequent publishing is achieved by passing the archive format
+in the message config part, for example::
+
+   message_config:
+     subject: /segment/viirs/l1b/
+     atype: dataset
+     archive_format: zip
+     data:
+       sensor: viirs
+     aliases:
+       platform_name:
+         npp: Suomi-NPP

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,0 +1,36 @@
+"""Tests for the publisher functionality."""
+
+import os
+from shutil import make_archive
+
+from posttroll.testing import patched_publisher
+from pytroll_watchers.publisher import file_publisher_from_generator
+from upath import UPath
+
+
+def test_unpacking(tmp_path):
+    """Test unpacking the watched file's components to a dataset message."""
+    file1 = tmp_path / "to_zip" / "file1"
+    file2 = tmp_path / "to_zip" / "file2"
+    zip_file = tmp_path / "archived.zip"
+
+    file1.parent.mkdir()
+
+    open(file1, "a").close()
+    open(file2, "a").close()
+
+    make_archive(os.path.splitext(zip_file)[0], "zip", tmp_path / "to_zip")
+
+    path = UPath("file://" + str(zip_file))
+
+    publisher_settings = dict(nameservers=False, port=1979)
+    message_settings = dict(subject="/segment/olci/l2/", atype="dataset", data=dict(sensor="olci"),
+                            archive_format="zip")
+
+    with patched_publisher() as messages:
+        file_publisher_from_generator([[path, dict()]],
+                                      publisher_config=publisher_settings,
+                                      message_config=message_settings)
+
+    assert "zip://file1" in messages[0]
+    assert "zip://file2" in messages[0]


### PR DESCRIPTION
This PR allows add the possibility to unpack the filenames when watching archive files, so that a dataset is published instead of a single file.