### PR TITLE
Fix tests for new version of fsspec

### DIFF
--- a/tests/test_bucket_notification_watcher.py
+++ b/tests/test_bucket_notification_watcher.py
@@ -108,7 +108,7 @@ def test_publish_paths(patched_bucket_listener, caplog):  # noqa
     assert message.data["uri"] == "s3://viirs-data/sdr/SVM13_npp_d20240408_t1006227_e1007469_b64498_c20240408102334392250_cspp_dev.h5"
     assert message.data["uid"] == "SVM13_npp_d20240408_t1006227_e1007469_b64498_c20240408102334392250_cspp_dev.h5"
     assert message.data["sensor"] == "viirs"
-    assert message.data["filesystem"] == {"cls": "s3fs.core.S3FileSystem", "protocol": "s3", "args": [],
+    assert message.data["filesystem"] == {"cls": "s3fs.core:S3FileSystem", "protocol": "s3", "args": [],
                                   "profile": "someprofile"}
     assert "Starting watch on 'viirs-data'" in caplog.text
 

--- a/tests/test_copernicus_dataspace_watcher.py
+++ b/tests/test_copernicus_dataspace_watcher.py
@@ -120,7 +120,7 @@ def test_publish_paths(caplog):
     assert message.data["uri"] == "s3:///eodata/Sentinel-3/OLCI/OL_1_EFR___/2024/04/15/S3B_OL_1_EFR____20240415T074029_20240415T074329_20240415T094236_0179_092_035_1620_PS2_O_NR_003.SEN3"
     assert message.data["uid"] == "S3B_OL_1_EFR____20240415T074029_20240415T074329_20240415T094236_0179_092_035_1620_PS2_O_NR_003.SEN3"  # noqa
     assert message.data["sensor"] == "olci"
-    assert message.data["filesystem"] == {"cls": "s3fs.core.S3FileSystem", "protocol": "s3", "args": [],
+    assert message.data["filesystem"] == {"cls": "s3fs.core:S3FileSystem", "protocol": "s3", "args": [],
                                   "profile": "someprofile"}
     assert message.data["path"] == "/eodata/Sentinel-3/OLCI/OL_1_EFR___/2024/04/15/S3B_OL_1_EFR____20240415T074029_20240415T074329_20240415T094236_0179_092_035_1620_PS2_O_NR_003.SEN3"  # noqa
     assert f"Starting watch on dataspace for '{filter_string}'" in caplog.text

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -138,7 +138,7 @@ def test_publish_paths(caplog, search_params):
     assert message.data["uri"] == uri
     assert message.data["sensor"] == "olci"
     assert message.data["filesystem"] == {
-        "cls": "fsspec.implementations.http.HTTPFileSystem",
+        "cls": "fsspec.implementations.http:HTTPFileSystem",
         "protocol": "https",
         "args": [],
         "encoded": True,


### PR DESCRIPTION
This PR fixes the tests following the filesystem serialization changes in the newer version of fsspec (2024.6.0)