### PR TITLE
Document the datastore watcher more

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ fail_fast: false
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.5.7'
+    rev: 'v0.6.3'
     hooks:
       - id: ruff
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/src/pytroll_watchers/datastore_watcher.py
+++ b/src/pytroll_watchers/datastore_watcher.py
@@ -58,7 +58,18 @@ def file_publisher(fs_config, publisher_config, message_config):
 
 
 def file_generator(search_params, polling_interval, ds_auth, start_from=None):
-    """Search params must contain at least collection."""
+    """Search params must contain at least collection.
+
+    Args:
+        search_params: the dictionary of search parameters to request. Based on the opensearch API:
+          https://user.eumetsat.int/api-definitions/data-store-opensearch-api
+        polling_interval: how often to poll for new data. Can be provided as a timedelta or a dictionary of arguments
+          for timedelta.
+        ds_auth: either a dictionary with `netrc_host` (and optionally `netrc_file`), or a dictionary with `username`
+          and `password`.
+        start_from: a timedelta or dictionary of arguments to timedelta to specify how far in time to start fetching
+          data. `None` by default, which means the data will be no older that now.
+    """
     with suppress(TypeError):
         polling_interval = datetime.timedelta(**polling_interval)
     with suppress(TypeError):

--- a/tests/test_bucket_notification_watcher.py
+++ b/tests/test_bucket_notification_watcher.py
@@ -6,10 +6,11 @@ from unittest import mock
 import pytest
 from posttroll.message import Message
 from posttroll.testing import patched_publisher
+from upath import UPath
+
 from pytroll_watchers import minio_notification_watcher
 from pytroll_watchers.publisher import SecurityError, fix_times
 from pytroll_watchers.testing import patched_bucket_listener  # noqa
-from upath import UPath
 
 sdr_file_pattern = ("sdr/SV{channel_name:3s}_{platform_name}_d{start_date:%Y%m%d}_t{start_time:%H%M%S%f}_"
                     "e{end_time:%H%M%S%f}_b{orbit_number:d}_c{processing_datetime:%Y%m%d%H%M%S%f}_cspp_dev.h5")

--- a/tests/test_copernicus_dataspace_watcher.py
+++ b/tests/test_copernicus_dataspace_watcher.py
@@ -4,6 +4,7 @@ import datetime
 from freezegun import freeze_time
 from posttroll.message import Message
 from posttroll.testing import patched_publisher
+
 from pytroll_watchers.dataspace_watcher import file_generator, file_publisher
 from pytroll_watchers.testing import load_oauth_responses
 

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -9,6 +9,7 @@ import yaml
 from freezegun import freeze_time
 from posttroll.message import Message
 from posttroll.testing import patched_publisher
+
 from pytroll_watchers.datastore_watcher import (
     file_generator,
     file_publisher,
@@ -17,7 +18,7 @@ from pytroll_watchers.datastore_watcher import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def search_params():
     """Generate the search parameters for the tests."""
     polygon = ("POLYGON((9.08 60.00,16.25 59.77,17.50 63.06,21.83 66.02,26.41 65.75,22.22 60.78,28.90 60.82,30.54 60.01"
@@ -112,7 +113,7 @@ def test_datastore_file_generator(tmp_path, search_params):
     assert expected_token in path.storage_options["client_kwargs"]["headers"]["Authorization"]
 
 
-@pytest.fixture()
+@pytest.fixture
 def search_params_geo():
     """Generate the search parameters for the tests."""
     collection = "EO:EUM:DAT:MSG:HRSEVIRI"

--- a/tests/test_dhus.py
+++ b/tests/test_dhus.py
@@ -8,6 +8,7 @@ import responses._recorder
 from freezegun import freeze_time
 from posttroll.message import Message
 from posttroll.testing import patched_publisher
+
 from pytroll_watchers.dhus_watcher import (
     file_generator,
     file_publisher,

--- a/tests/test_local_watcher.py
+++ b/tests/test_local_watcher.py
@@ -5,6 +5,7 @@ import os
 import pytest
 from posttroll.message import Message
 from posttroll.testing import patched_publisher
+
 from pytroll_watchers import local_watcher
 from pytroll_watchers.publisher import SecurityError
 from pytroll_watchers.testing import patched_local_events  # noqa

--- a/tests/test_main_interface.py
+++ b/tests/test_main_interface.py
@@ -8,6 +8,8 @@ import pytest
 import yaml
 from posttroll.message import Message
 from posttroll.testing import patched_publisher
+from upath import UPath
+
 from pytroll_watchers.local_watcher import file_generator as local_generator
 from pytroll_watchers.local_watcher import file_publisher as local_publisher
 from pytroll_watchers.main_interface import (
@@ -19,7 +21,6 @@ from pytroll_watchers.main_interface import (
 from pytroll_watchers.minio_notification_watcher import file_generator as minio_generator
 from pytroll_watchers.minio_notification_watcher import file_publisher as minio_publisher
 from pytroll_watchers.testing import patched_bucket_listener, patched_local_events  # noqa
-from upath import UPath
 
 
 def test_getting_right_publisher():

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -4,8 +4,9 @@ import os
 from shutil import make_archive
 
 from posttroll.testing import patched_publisher
-from pytroll_watchers.publisher import file_publisher_from_generator
 from upath import UPath
+
+from pytroll_watchers.publisher import file_publisher_from_generator
 
 
 def test_unpacking(tmp_path):

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 from posttroll.message import Message
 from posttroll.testing import patched_publisher, patched_subscriber_recv
+
 from pytroll_watchers.selector import (
     TTLDict,
     _run_selector_with_managed_dict_server,


### PR DESCRIPTION
This PR adds more documentation to the datastore watcher.

Fix the pre-commit ruff version and closes #26 