### PR TITLE
Fix filesystem serialisation to avoid connection

### DIFF
--- a/src/pytroll_watchers/local_watcher.py
+++ b/src/pytroll_watchers/local_watcher.py
@@ -1,6 +1,22 @@
 """Watcher for non-remote file systems.
 
 Either using OS-based envents (like inotify on linux), or polling.
+
+An example configuration file to retrieve data from a directory.
+
+.. code-block:: yaml
+
+  backend: local
+  fs_config:
+    directory: /data
+    file pattern: "H-000-{orig_platform_name:4s}__-{orig_platform_name:4s}_{service:3s}____-{channel_name:_<9s}-\
+        {segment:_<9s}-{start_time:%Y%m%d%H%M}-{compression:1s}_"
+  publisher_config:
+    name: hrit_watcher
+  message_config:
+    subject: /segment/hrit/l1b/
+    atype: file
+
 """
 import logging
 import os

--- a/tests/test_local_watcher.py
+++ b/tests/test_local_watcher.py
@@ -118,3 +118,26 @@ def test_publish_paths_forbids_passing_password(tmp_path, patched_local_events, 
                 local_watcher.file_publisher(fs_config=local_settings,
                                              publisher_config=publisher_settings,
                                              message_config=message_settings)
+
+
+def test_publish_paths_with_ssh(tmp_path, patched_local_events, caplog):  # noqa
+    """Test publishing paths with an ssh protocol."""
+    filename = os.fspath(tmp_path / "foo.txt")
+
+    host = "localhost"
+
+    local_settings = dict(directory=tmp_path, protocol="ssh",
+                          storage_options=dict(host=host))
+    publisher_settings = dict(nameservers=False, port=1979)
+    message_settings = dict(subject="/segment/viirs/l1b/", atype="file", data=dict(sensor="viirs"))
+
+    caplog.set_level("INFO")
+    with patched_local_events([filename]):
+        with patched_publisher() as published_messages:
+            local_watcher.file_publisher(fs_config=local_settings,
+                                         publisher_config=publisher_settings,
+                                         message_config=message_settings)
+            assert len(published_messages) == 1
+            message = Message(rawstr=published_messages[0])
+            assert message.data["uri"].startswith("ssh://")
+            assert message.data["filesystem"]["host"] == host

--- a/tests/test_local_watcher.py
+++ b/tests/test_local_watcher.py
@@ -120,7 +120,7 @@ def test_publish_paths_forbids_passing_password(tmp_path, patched_local_events, 
                                              message_config=message_settings)
 
 
-def test_publish_paths_with_ssh(tmp_path, patched_local_events, caplog):  # noqa
+def test_publish_paths_with_ssh(tmp_path, patched_local_events):  # noqa
     """Test publishing paths with an ssh protocol."""
     filename = os.fspath(tmp_path / "foo.txt")
 
@@ -131,7 +131,6 @@ def test_publish_paths_with_ssh(tmp_path, patched_local_events, caplog):  # noqa
     publisher_settings = dict(nameservers=False, port=1979)
     message_settings = dict(subject="/segment/viirs/l1b/", atype="file", data=dict(sensor="viirs"))
 
-    caplog.set_level("INFO")
     with patched_local_events([filename]):
         with patched_publisher() as published_messages:
             local_watcher.file_publisher(fs_config=local_settings,


### PR DESCRIPTION
Sometimes it's difficult to get the json representation of an ssh filesystem because the host is maybe not reachable by itself for example.
This PR monkey patches the (private!) connection method of the filesystem to allow serialisation without connection.