### PR TITLE
Suppress unwanted character encoding on local files

### DIFF
--- a/src/pytroll_watchers/publisher.py
+++ b/src/pytroll_watchers/publisher.py
@@ -5,6 +5,7 @@ import json
 import logging
 from contextlib import closing, contextmanager, suppress
 from copy import deepcopy
+from urllib.parse import unquote
 
 import fsspec
 from posttroll.message import Message
@@ -85,7 +86,7 @@ def unpack_archive(path, unpack):
                     protocol=unpack,
                     target_protocol=path.protocol,
                     target_options=path.storage_options,
-                    fo=path.as_uri())
+                    fo=as_uri(path))
 
 
 def unpack_dir(path):
@@ -99,7 +100,7 @@ def unpack_dir(path):
 
 def _build_file_location(file_item, include_dir=None):
     file_location = dict()
-    file_location["uri"] = file_item.as_uri()
+    file_location["uri"] = as_uri(file_item)
     if include_dir:
         uid = include_dir + file_item.path.rsplit(include_dir, 1)[-1]
     else:
@@ -112,6 +113,14 @@ def _build_file_location(file_item, include_dir=None):
         file_location["path"] = file_item.path
 
     return file_location
+
+def as_uri(file_item):
+    """Represent file item’s path as an unquoted uri."""
+    with suppress(AttributeError):
+        protocol = file_item.protocol
+        if protocol.startswith("http"):
+            return file_item.as_uri()
+    return unquote(file_item.as_uri())
 
 
 @contextmanager

--- a/tests/test_local_watcher.py
+++ b/tests/test_local_watcher.py
@@ -79,7 +79,8 @@ def test_watchdog_generator_with_something_else(tmp_path):
 
 def test_publish_paths(tmp_path, patched_local_events, caplog):  # noqa
     """Test publishing paths."""
-    filename = os.fspath(tmp_path / "foo.txt")
+    basename = "foo+bar,baz_.txt"
+    filename = os.fspath(tmp_path / basename)
 
     local_settings = dict(directory=tmp_path)
     publisher_settings = dict(nameservers=False, port=1979)
@@ -95,7 +96,7 @@ def test_publish_paths(tmp_path, patched_local_events, caplog):  # noqa
     assert "uri" not in message_settings["data"]
     assert len(messages) == 1
     message = Message(rawstr=messages[0])
-    assert message.data["uri"] == f"file://{str(tmp_path)}/foo.txt"
+    assert message.data["uri"] == f"file://{str(tmp_path)}/{basename}"
     assert message.data["sensor"] == "viirs"
     assert "filesystem" not in message.data
     assert f"Starting watch on '{local_settings['directory']}'" in caplog.text


### PR DESCRIPTION
This PR suppresses unwanted character encoding on local files, for example on FCI filenames.