### PR TITLE
Remove filesystem info for local files by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ wheels/
 
 # venv
 .venv
+
+# pixi environments
+pixi.toml
+.pixi
+*.egg-info

--- a/docs/source/published.rst
+++ b/docs/source/published.rst
@@ -71,7 +71,7 @@ Examples of paths:
 Other metadata
 ==============
 
-Other metadata items are provided when possible:
+Other metadata items gatherer from the data service are provided when possible:
 
 * boundary: the geojson boundary of the data
 * platform_name
@@ -81,3 +81,22 @@ Other metadata items are provided when possible:
 * end_time
 * product_type
 * checksum
+
+For the "local" backend, this data comes from the configured file pattern. The other items in the file pattern will be
+included too.
+
+Customizing the messages published by pytroll-watcher
+=====================================================
+
+The messages sent with the publisher will contain the information mentioned above, but sometimes it can be necessary to
+provide additional static metadata. These can be added to the `message_config` of the yaml file passed to the
+pytroll-watcher script, eg::
+
+  ...
+  message_config:
+    subject: /segment/viirs/l1b/
+    atype: file
+    data:
+      sensor: viirs
+      var_platform_name: NOAA-20
+      var_agency: NOAA

--- a/src/pytroll_watchers/local_watcher.py
+++ b/src/pytroll_watchers/local_watcher.py
@@ -4,12 +4,12 @@ Either using OS-based envents (like inotify on linux), or polling.
 
 An example configuration file to retrieve data from a directory.
 
-For backwards compatibility with pytroll collector’s trollstalker, the message config can have the `no_fs` set to
-`true` to sent messages without filesystem information and without `file://` prepended to the file uri.
+By default, files uris will not include any protocol, which means they will look like `/tmp/myfile`. If it is desired,
+the `protocol` setting in the `fs_config` can be set to `"file"` to make the uris look like `file:///tmp/myfile`.
 
-It is also possible to make the local files sent as remote with the `protocol` and `storage_options` setting in the
-fs_config section. So instead of starting with `file://`, the generated uri can start with `ssh://myhost` for example,
-by setting `protocol: ssh` and `storage_options: {host: host}`. Note that this is incompatible with `no_fs`.
+It is also possible to make the local files sent as remote with the `protocol` and `storage_options` settings in the
+`fs_config` section. The generated uri can thus start with `ssh://myhost` for example, by setting `protocol: ssh` and
+`storage_options: {host: "myhost"}`.
 
 
 .. code-block:: yaml

--- a/src/pytroll_watchers/local_watcher.py
+++ b/src/pytroll_watchers/local_watcher.py
@@ -4,6 +4,14 @@ Either using OS-based envents (like inotify on linux), or polling.
 
 An example configuration file to retrieve data from a directory.
 
+For backwards compatibility with pytroll collector’s trollstalker, the message config can have the `no_fs` set to
+`true` to sent messages without filesystem information and without `file://` prepended to the file uri.
+
+It is also possible to make the local files sent as remote with the `protocol` and `storage_options` setting in the
+fs_config section. So instead of starting with `file://`, the generated uri can start with `ssh://myhost` for example,
+by setting `protocol: ssh` and `storage_options: {host: host}`. Note that this is incompatible with `no_fs`.
+
+
 .. code-block:: yaml
 
   backend: local

--- a/src/pytroll_watchers/publisher.py
+++ b/src/pytroll_watchers/publisher.py
@@ -101,14 +101,15 @@ def unpack_dir(path):
 
 def _build_file_location(file_item, include_dir=None):
     file_location = dict()
-    no_fs = not isinstance(file_item, UPath)
-    with suppress(AttributeError):  # fileitem is not a UPath if it cannot access .fs
+    try:
         with dummy_connect(file_item):
             file_location["filesystem"] = json.loads(file_item.fs.to_json(include_password=False))
 
+        file_location["uri"] = as_uri(file_item)
         file_location["path"] = file_item.path
+    except AttributeError:  # fileitem is not a UPath if it cannot access .fs
+        file_location["uri"] = str(file_item)
 
-    file_location["uri"] = str(file_item) if no_fs else as_uri(file_item)
     if include_dir:
         uid = include_dir + file_item.path.rsplit(include_dir, 1)[-1]
     else:

--- a/tests/test_local_watcher.py
+++ b/tests/test_local_watcher.py
@@ -141,3 +141,42 @@ def test_publish_paths_with_ssh(tmp_path, patched_local_events):  # noqa
             message = Message(rawstr=published_messages[0])
             assert message.data["uri"].startswith("ssh://")
             assert message.data["filesystem"]["host"] == host
+
+
+def test_publish_no_fs(tmp_path, patched_local_events):  # noqa
+    """Test that the filesystem functionality can be switched off."""
+    filename = os.fspath(tmp_path / "foo.txt")
+
+
+    local_settings = dict(directory=tmp_path)
+    publisher_settings = dict(nameservers=False, port=1979)
+    message_settings = dict(subject="/segment/viirs/l1b/", atype="file", data=dict(sensor="viirs"), no_fs=True)
+
+    with patched_local_events([filename]):
+        with patched_publisher() as published_messages:
+            local_watcher.file_publisher(fs_config=local_settings,
+                                         publisher_config=publisher_settings,
+                                         message_config=message_settings)
+            assert len(published_messages) == 1
+            message = Message(rawstr=published_messages[0])
+            assert message.data["uri"].startswith("/")  # or `os.sep` ?
+            assert "filesystem" not in message.data
+
+
+def test_publish_no_fs_errors_with_remote_files(tmp_path, patched_local_events):  # noqa
+    """Test publishing paths with an ssh protocol and no_fs."""
+    filename = os.fspath(tmp_path / "foo.txt")
+
+    host = "localhost"
+
+    local_settings = dict(directory=tmp_path, protocol="ssh",
+                          storage_options=dict(host=host))
+    publisher_settings = dict(nameservers=False, port=1979)
+    message_settings = dict(subject="/segment/viirs/l1b/", atype="file", data=dict(sensor="viirs"), no_fs=True)
+
+    with patched_local_events([filename]):
+        with patched_publisher():
+            with pytest.raises(ValueError, match="no_fs"):
+                local_watcher.file_publisher(fs_config=local_settings,
+                                             publisher_config=publisher_settings,
+                                             message_config=message_settings)


### PR DESCRIPTION
This PR removes the `file://` prefix by default for the local watcher, and instead allows `file` to be passed as a protocol.
Some documentation was also added to explain message customisation.
- Fixes #41
- Fixes #42 
