### PR TITLE
Hear sigterm and allow env-based credentials

### DIFF
--- a/src/pytroll_watchers/backends/local.py
+++ b/src/pytroll_watchers/backends/local.py
@@ -2,14 +2,16 @@
 
 import fnmatch
 import os
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from functools import partial
-from queue import Queue
+from queue import Empty, Queue
 
 from trollsift import globify
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
+
+from pytroll_watchers.common import TERM_EVENT
 
 
 @contextmanager
@@ -85,7 +87,9 @@ def _iterate_over_queue(queue):
 
     This is it's own function so that it can be mocked during tests.
     """
-    return iter(queue.get, None)
+    while not TERM_EVENT.is_set():
+        with suppress(Empty):
+            yield queue.get(timeout=1)
 
 
 def _create_watchdog_observer(directory, function_to_run, glob_pattern, observer_class, handler_class):

--- a/src/pytroll_watchers/common.py
+++ b/src/pytroll_watchers/common.py
@@ -1,8 +1,26 @@
 """Collection of function needed by multiple watchers."""
 
 import datetime
+import netrc
+import signal
 import time
 from collections.abc import Generator
+from logging import getLogger
+from os import environ
+from threading import Event
+
+logger = getLogger(__name__)
+
+TERM_EVENT = Event()
+
+
+def handle_sigterm(signum, frame):
+    """Handle sigterm."""
+    logger.info(f"Received SIGTERM ({signum}). Cleaning up...")
+    TERM_EVENT.set()
+
+
+signal.signal(signal.SIGTERM, handle_sigterm)
 
 
 def run_every(interval: datetime.timedelta) -> Generator[datetime.datetime]:
@@ -10,18 +28,19 @@ def run_every(interval: datetime.timedelta) -> Generator[datetime.datetime]:
 
     Args:
         interval: the timedelta object giving the amount of time to wait between ticks. An interval of 0 will just make
-        tick once, then return (and thus busy loops aren't allowed).
+        tick once, then return (and thus busy loops aren't allowed). Can be interrupting by setting TERM_EVENT or by
+        sending SIGTERM.
 
     Yields:
         The time of the next tick.
     """
     next_check = datetime.datetime.now(datetime.timezone.utc)
-    while True:
+    while not TERM_EVENT.is_set():
         next_check += interval
         yield next_check
         to_wait = max(next_check.timestamp() - time.time(), 0)
-        time.sleep(to_wait)
-        if not interval:  # interval is 0
+        to_be_continued = TERM_EVENT.wait(to_wait)
+        if not interval and not to_be_continued:  # interval is 0
            break
 
 
@@ -32,3 +51,16 @@ def fromisoformat(datestring):
     except ValueError:
         # for python 3.10
         return datetime.datetime.strptime(datestring, "%Y-%m-%dT%H:%M:%S.%f%z")
+
+
+def get_oauth_credentials(ds_auth: dict[str, str]) -> tuple[str, str]:
+    """Get credentials from the ds_auth dictionary or the enviromnent."""
+    try:
+        try:
+            creds = ds_auth["username"], ds_auth["password"]
+        except KeyError:
+            creds = environ["OAUTH_USERNAME"], environ["OAUTH_PASSWORD"]
+    except KeyError:
+        username, _, password = netrc.netrc(ds_auth.get("netrc_file")).authenticators(ds_auth["netrc_host"])
+        creds = (username, password)
+    return creds

--- a/src/pytroll_watchers/dataspace_watcher.py
+++ b/src/pytroll_watchers/dataspace_watcher.py
@@ -4,7 +4,10 @@ It polls the catalogue using OData for new data (https://documentation.dataspace
 generates locations for the data on the S3 services (https://documentation.dataspace.copernicus.eu/APIs/S3.html).
 
 Note:
-    The OData and S3 services require two different set of credentials.
+    The OData and S3 services require two different set of credentials. OData credentials can be passed as
+    "username" and "password" in the configuration file, as "OAUTH_USERNAME" and "OAUTH_PASSWORD" in the environment
+    or in a netrc file pointed to by the config's "netrc_file" (optional for `~/.netrc`) and "netrc_host".
+    S3 credentials can be passed through the standard AWS config files or environment variables.
 
 
 Example of configuration file to retrieve SAR data from dataspace:
@@ -41,7 +44,6 @@ Example of configuration file to retrieve SAR data from dataspace:
 
 import datetime
 import logging
-import netrc
 import time
 from contextlib import suppress
 from functools import cache
@@ -50,7 +52,7 @@ from oauthlib.oauth2 import LegacyApplicationClient
 from requests_oauthlib import OAuth2Session
 from upath import UPath
 
-from pytroll_watchers.common import fromisoformat, run_every
+from pytroll_watchers.common import fromisoformat, get_oauth_credentials, run_every
 from pytroll_watchers.publisher import file_publisher_from_generator
 
 client_id = "cdse-public"
@@ -197,7 +199,7 @@ class CopernicusOAuth2Session():
 
     def __init__(self, dataspace_auth):
         """Set up the session."""
-        dataspace_credentials = _get_credentials(dataspace_auth)
+        dataspace_credentials = get_oauth_credentials(dataspace_auth)
         self._oauth = OAuth2Session(client=LegacyApplicationClient(client_id=client_id))
         def compliance_hook(response):
             response.raise_for_status()
@@ -226,13 +228,3 @@ class CopernicusOAuth2Session():
             self._oauth.fetch_token(token_url=token_url,
                                     username=self._token_user,
                                     password=self._token_pass)
-
-
-def _get_credentials(ds_auth):
-    """Get credentials from the ds_auth dictionary."""
-    try:
-        creds = ds_auth["username"], ds_auth["password"]
-    except KeyError:
-        username, _, password = netrc.netrc(ds_auth.get("netrc_file")).authenticators(ds_auth["netrc_host"])
-        creds = (username, password)
-    return creds

--- a/src/pytroll_watchers/datastore_watcher.py
+++ b/src/pytroll_watchers/datastore_watcher.py
@@ -6,6 +6,12 @@ Note:
     The links produced can only be downloaded with a valid token. A token comes with the links, but
     has only a limited validity time (maybe 5 minutes).
 
+Note:
+    OAuth credentials can be passed as
+    "username" and "password" in the configuration file, as "OAUTH_USERNAME" and "OAUTH_PASSWORD" in the environment
+    or in a netrc file pointed to by the config's "netrc_file" (optional for `~/.netrc`) and "netrc_host".
+
+
 An example for getting links to MSG data::
 
     from pytroll_watchers.datastore_watcher import generate_download_links_since
@@ -45,10 +51,8 @@ Another example, here a configuration file to pass to the CLI::
         platform_name: AWS1
         variant: GDS
 """
-
 import datetime
 import logging
-import netrc
 import time
 from collections.abc import Generator
 from contextlib import suppress
@@ -58,7 +62,7 @@ from oauthlib.oauth2 import BackendApplicationClient
 from requests_oauthlib import OAuth2Session
 from upath import UPath
 
-from pytroll_watchers.common import fromisoformat, run_every
+from pytroll_watchers.common import fromisoformat, get_oauth_credentials, run_every
 from pytroll_watchers.publisher import file_publisher_from_generator
 from pytroll_watchers.version import version
 
@@ -179,7 +183,7 @@ class DatastoreOAuth2Session():
 
     def __init__(self, datastore_auth):
         """Set up the session."""
-        client_id, client_secret = _get_credentials(datastore_auth)
+        client_id, client_secret = get_oauth_credentials(datastore_auth)
         self._oauth = OAuth2Session(client=BackendApplicationClient(client_id=client_id))
         def compliance_hook(response):
             response.raise_for_status()
@@ -209,13 +213,3 @@ class DatastoreOAuth2Session():
                                     client_secret=self._token_secret,
                                     include_client_id=True)
         return self._oauth.token
-
-
-def _get_credentials(ds_auth: dict[str, str]) -> tuple[str, str]:
-    """Get credentials from the ds_auth dictionary."""
-    try:
-        creds = ds_auth["username"], ds_auth["password"]
-    except KeyError:
-        username, _, password = netrc.netrc(ds_auth.get("netrc_file")).authenticators(ds_auth["netrc_host"])
-        creds = (username, password)
-    return creds

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,47 @@
+"""Test the common utilities."""
+
+from datetime import timedelta
+from signal import SIGTERM
+from threading import Thread
+from time import sleep
+
+from pytroll_watchers.common import TERM_EVENT, get_oauth_credentials, handle_sigterm, run_every
+
+
+def test_run_every_terminates():
+    """Test that run_every terminates."""
+    res = []
+    def runner():
+        for _ in run_every(timedelta(seconds=1)):
+            res.append("test")
+    thr = Thread(target=runner)
+    thr.start()
+    sleep(.01)
+    TERM_EVENT.set()
+    thr.join()
+    assert len(res) == 1
+    TERM_EVENT.clear()
+
+
+def test_run_every_sigterm():
+    """Test that run_every terminates on sigterm."""
+    res = []
+    def runner():
+        for _ in run_every(timedelta(seconds=1)):
+            res.append("test")
+    thr = Thread(target=runner)
+    thr.start()
+    sleep(.01)
+    handle_sigterm(SIGTERM, None)
+    thr.join()
+    assert len(res) == 1
+    TERM_EVENT.clear()
+
+
+def test_get_oauth_credentials_use_env(monkeypatch):
+    """Test that credentials can be passed through the env."""
+    user = "user1"
+    passwd = "pass2"  # noqa
+    monkeypatch.setenv("OAUTH_USERNAME", user)
+    monkeypatch.setenv("OAUTH_PASSWORD", passwd)
+    assert get_oauth_credentials(dict()) == (user, passwd)


### PR DESCRIPTION
This PR make the pytroll watcher obey to sigterm and allow passing env variables "OAUTH_USERNAME" and "OAUTH_PASSWORD" for oauth credentials.